### PR TITLE
Remove trailing whitespace in libxdg-basedir.pc

### DIFF
--- a/pkgconfig/libxdg-basedir.pc.in
+++ b/pkgconfig/libxdg-basedir.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@ 
+includedir=@includedir@
 
 Name: libxdg-basedir
 Description: An implementation of the XDG Base Directory specification


### PR DESCRIPTION
Silences an inconsequential whitespace warning with `pkgconf --validate`.
```
libxdg-basedir.pc:4: warning: trailing whitespace encountered while parsing value section
```